### PR TITLE
Fix MinimalReceiver

### DIFF
--- a/contracts/ERC6551Account.sol
+++ b/contracts/ERC6551Account.sol
@@ -12,7 +12,7 @@ import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 import "./lib/MinimalReceiver.sol";
 import "./lib/ERC6551AccountLib.sol";
 
-contract ERC6551Account is IERC165, IERC1271, IERC6551Account {
+contract ERC6551Account is MinimalReceiver, IERC1271, IERC6551Account {
     uint256 public nonce;
 
     receive() external payable {}
@@ -58,7 +58,7 @@ contract ERC6551Account is IERC165, IERC1271, IERC6551Account {
     }
 
     function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
-        return (interfaceId == type(IERC165).interfaceId ||
+        return (interfaceId == super.supportsInterface(interfaceId) ||
             interfaceId == type(IERC6551Account).interfaceId);
     }
 


### PR DESCRIPTION
Fix MinimalReceiver.

- Inherit MinimalReceiver on ERC6551Account
- Adapt the supportsInterface function to check the MinimalReceiver interface too.

IMPORTANT * IMPORTANT * IMPORTANT * IMPORTANT * IMPORTANT * IMPORTANT
************************************** NOT TESTED ***********************************************
- I did the changes on the github site. I did not test it. I guess it should work now. If any conflict about 165 appears, I would recommend to remove the MinimalReceiver and implement the TokenCallbackHandler as in: https://github.com/jvaleskadevs/erc1155-token-bound-account/blob/main/contracts/callback/TokenCallbackHandler.sol
IMPORTANT * IMPORTANT * IMPORTANT * IMPORTANT * IMPORTANT * IMPORTANT
************************************** NOT TESTED ***********************************************